### PR TITLE
Support independent mode in LZ4 compressor

### DIFF
--- a/cramjam-python/src/lz4.rs
+++ b/cramjam-python/src/lz4.rs
@@ -210,10 +210,15 @@ pub struct Compressor {
 impl Compressor {
     /// Initialize a new `Compressor` instance.
     #[new]
-    pub fn __init__(level: Option<u32>) -> PyResult<Self> {
+    pub fn __init__(level: Option<u32>, block_linked: Option<bool>) -> PyResult<Self> {
+        let block_mode = match block_linked {
+            Some(false) => libcramjam::lz4::lz4::BlockMode::Independent,
+            _ => libcramjam::lz4::lz4::BlockMode::Linked,
+        };
         let inner = libcramjam::lz4::lz4::EncoderBuilder::new()
             .auto_flush(true)
             .level(level.unwrap_or_else(|| DEFAULT_COMPRESSION_LEVEL))
+            .block_mode(block_mode)
             .build(Cursor::new(vec![]))?;
         Ok(Self { inner: Some(inner) })
     }


### PR DESCRIPTION
This PR adds 2 parameters to `Compressor` class: `block_linked` to allow switching to independent block mode and `content_checksum` to allow disabling content checksum. The parameters are named the same way, as they are in [python-lz4](https://python-lz4.readthedocs.io/en/stable/lz4.frame.html#lz4.frame.compress).

Motivation. `cramjam` is used in `aiokafka` for most codecs, but it's not possible to use it for LZ4. The problem is that kafka broker doesn't support linked block mode (see [KIP-57](https://cwiki.apache.org/confluence/display/KAFKA/KIP-57+-+Interoperable+LZ4+Framing) for the reference). Although kafka broker does support content checksum, it doesn't use it itself and using it in producer may cause problems with some consumers.