### PR TITLE
In libcramjam, bump zstd to 0.13.0 (to go with zstd-safe 7.0.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
  "snap",
  "xz2",
  "zstd",
- "zstd-safe 7.0.0",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -1276,21 +1276,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/libcramjam/Cargo.toml
+++ b/libcramjam/Cargo.toml
@@ -18,7 +18,7 @@ bzip2 = "^0.4"
 lz4 = "^1"
 flate2 = "^1"
 libdeflater = "^1"
-zstd = "0.11.1+zstd.1.5.2"
+zstd = "0.13.0"
 zstd-safe = "7.0.0"  # NOTE: This is the same dep version as zstd, as they don't re-export
 libc = { version = "0.2", optional = true }
 xz2 = { version = "0.1.7", features = ["static"] }


### PR DESCRIPTION
Suggested in https://bugzilla.redhat.com/show_bug.cgi?id=2257076#c6.

See: https://github.com/gyscos/zstd-rs/tags