### PR TITLE
Cargo.toml: set workspace.resolver to 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "cramjam-cli",
   "cramjam-python"
 ]
+resolver = "2"
 
 [workspace.package]
 edition = "2021"


### PR DESCRIPTION
Fixes:
```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```

If I'm not mistaken, this is seen in invocation of `cargo vendor cargo-deps-vendor.tar.gz --respect-source-config` over cramjam-python.