### PR TITLE
Update libcramjam crate to 0.3.0 in cramjam-cli

### DIFF
--- a/cramjam-cli/Cargo.toml
+++ b/cramjam-cli/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 clap = { version = "^4.2", features = ["derive"] }
 bytesize = "^1"
-libcramjam = "0.2.0"
+libcramjam = "0.3.0"


### PR DESCRIPTION
Even though this PR doesn’t contain the necessary work to actually expose the new xz support in the CLI, there don’t appear to be any relevant backwards-incompatibilities from `libcramjam` 0.2.x to 0.3.x, so it should be safe to build with the current release. The executable still builds, and I used `pytest` to confirm the tests still pass, with this PR applied.

Applying this as a downstream patch for [`cramjam-cli` 0.1.1 in Fedora](https://src.fedoraproject.org/rpms/cramjam-cli) will allow me to avoid carrying a [`rust-libcramjam0.2` compat package](https://src.fedoraproject.org/rpms/rust-libcramjam0.2) in Fedora 40 and later. (I plan to use the compat package in the stable Fedora 38 and 39 releases to avoid breaking the C ABIs of the existing packaged `libcramjam` shared libraries.)