### PR TITLE
Don't overwrite artifact on each job

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -321,7 +321,7 @@ jobs:
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3
-        # if: ${{ ( startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/tags/') ) }}
+        if: ${{ ( startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/tags/') ) }}
         with:
           name: dist
           path: dist
@@ -348,7 +348,7 @@ jobs:
 
   pypi-publish:
     name: Upload ${{ matrix.package }} release to PyPI
-    # if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     strategy:
       fail-fast: false
       matrix:
@@ -380,8 +380,8 @@ jobs:
 
         ls -l
 
-    # - name: Publish package distributions to PyPI
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     skip-existing: true
-    #     packages-dir: artifacts-${{ matrix.package }}/
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        skip-existing: true
+        packages-dir: artifacts-${{ matrix.package }}/

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -320,12 +320,11 @@ jobs:
             venv/bin/python -c 'import cramjam' || venv/bin/cramjam-cli --help
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        if: ${{ ( startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/tags/') ) }}
+        uses: actions/upload-artifact@v3
+        # if: ${{ ( startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/tags/') ) }}
         with:
           name: dist
           path: dist
-          overwrite: true
 
   build-sdist:
     name: Build sdists
@@ -342,14 +341,14 @@ jobs:
       - name: Build sdist cramjam-cli
         run: python -m build --sdist cramjam-cli/ -o ./dist
       - name: Upload sdists
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist
 
   pypi-publish:
     name: Upload ${{ matrix.package }} release to PyPI
-    if: startsWith(github.ref, 'refs/tags/')
+    # if: startsWith(github.ref, 'refs/tags/')
     strategy:
       fail-fast: false
       matrix:
@@ -381,8 +380,8 @@ jobs:
 
         ls -l
 
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        skip-existing: true
-        packages-dir: artifacts-${{ matrix.package }}/
+    # - name: Publish package distributions to PyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     skip-existing: true
+    #     packages-dir: artifacts-${{ matrix.package }}/

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -11,6 +11,9 @@ on:
       - released
       - prereleased
 
+permissions:
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -385,3 +388,10 @@ jobs:
       with:
         skip-existing: true
         packages-dir: artifacts-${{ matrix.package }}/
+
+    - name: Upload to GitHub
+      uses: softprops/action-gh-release@v2
+      with:
+        files: artifacts-${{ matrix.package }}/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Annoying upload-artifact@v4 is not additive, each upload overwrites the previous (, or just fails w/o setting `overwrite: true`). So falling back to v3, can possibly use the one I wrote [artifact-mover](https://github.com/marketplace/actions/artifact-mover) but that uses S3. Maybe stick with v3 until it's officially retired nov 2024 and something changes there before then.