### PR TITLE
Bump libcramjam/isal-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ wasm32-compat            = ["libcramjam/wasm32-compat"]
 
 [dependencies]
 pyo3 = { version = "^0.22", default-features = false, features = ["macros"] }
-libcramjam = { version = "0.5.2", default-features = false }
+libcramjam = { version = "^0.5", default-features = false }
 
 [build-dependencies]
 pyo3-build-config = "^0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cramjam-python"
-version = "2.8.4"
+version = "2.8.5-rc1"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -53,7 +53,7 @@ wasm32-compat            = ["libcramjam/wasm32-compat"]
 
 [dependencies]
 pyo3 = { version = "^0.22", default-features = false, features = ["macros"] }
-libcramjam = { version = "0.5.1", default-features = false }
+libcramjam = { version = "0.5.2", default-features = false }
 
 [build-dependencies]
 pyo3-build-config = "^0.22"

--- a/src/igzip.rs
+++ b/src/igzip.rs
@@ -63,7 +63,7 @@ pub mod igzip {
     /// IGZIP Compressor object for streaming compression
     #[pyclass(unsendable)] // TODO: make sendable
     pub struct Compressor {
-        inner: Option<libcramjam::igzip::isal::igzip::write::Encoder<Cursor<Vec<u8>>>>,
+        inner: Option<libcramjam::igzip::isal::write::GzipEncoder<Cursor<Vec<u8>>>>,
     }
 
     #[pymethods]
@@ -73,11 +73,10 @@ pub mod igzip {
         #[pyo3(signature = (level=None))]
         pub fn __init__(level: Option<u32>) -> PyResult<Self> {
             let level = level.unwrap_or(DEFAULT_COMPRESSION_LEVEL);
-            let inner = libcramjam::igzip::isal::igzip::write::Encoder::new(
+            let inner = libcramjam::igzip::isal::write::GzipEncoder::new(
                 Cursor::new(vec![]),
-                libcramjam::igzip::isal::igzip::CompressionLevel::try_from(level as isize)
+                libcramjam::igzip::isal::CompressionLevel::try_from(level as isize)
                     .map_err(CompressionError::from_err)?,
-                true,
             );
             Ok(Self { inner: Some(inner) })
         }


### PR DESCRIPTION
Further improvements in isal-rs implementation; should probably add the zlib and deflate impls here as well which are much faster than present implementation.

zlib would be a new addition as well, but is anyway available in flate2. 

After experimental phase, should we auto-enable it on 64bit platforms for gzip, zlib and deflate, falling back to flate2? Seems okay, but the default compression for gzip is 6, but for isal, only 0, 1, 3 are supported....maybe a change for a 3.0 release?