### PR TITLE
Updates for Maturin 1.8: add a version key in the project metadata #64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "cramjam"
+version = "2.9.1"
 keywords = ["compression", "decompression", "snappy", "zstd", "bz2", "gzip", "lz4", "brotli", "deflate", "blosc2"]
 requires-python = ">=3.8"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Description

Through https://github.com/PyO3/maturin/pull/2391 via the recently released https://github.com/PyO3/maturin/releases/tag/v1.8.0, we've been seeing failing builds for `cramjam` in Pyodide ([logs](https://app.circleci.com/pipelines/github/pyodide/pyodide/8375/workflows/56df26fc-2fd3-4689-b20e-52a1a7a6347f/jobs/122629?invite=true#step-106-30059_80)).

I've opened this PR to fix the failure here, and I shall be applying this PR as a patch to fix the failing builds. If you'd like me to set it as a dynamic attribute or something else of your liking, please let me know. Thank you!

## Additional context

- List of changes for Maturin 1.8.0: https://github.com/PyO3/maturin/blob/main/Changelog.md#180