### PR TITLE
Remove experimental codecs in default builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,102 +88,16 @@ jobs:
         with:
           target: ${{ matrix.conf.target-triple }}
 
-      - name: Install nasm (Windows / Linux)
-        if: runner.os != 'macOS'
-        uses: ilammy/setup-nasm@v1
-
-      - name: Set MSVC developer prompt
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Setup (Mac)
-        if: runner.os == 'macOS'
-        run: |
-          brew install ninja automake autoconf coreutils libtool nasm
-          echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
-
-      - name: Setup (Windows)
-        if: runner.os == 'Windows'
-        uses: lukka/get-cmake@latest
-
-      - name: Setup (Linux)
-        if: runner.os == 'Linux'
-        env: 
-          TARGET_TRIPLE: ${{ matrix.conf.target-triple }}
-          WORKSPACE: ${{ github.workspace }}
-          BLOSC2_INSTALL_PREFIX: ${{ github.workspace }}/blosc2
-          ISAL_INSTALL_PREFIX: ${{ github.workspace }}/isal
-        run: |
-          sudo apt update
-          sudo apt install ninja-build -y
-
-          echo "BLOSC2_INSTALL_PREFIX=$BLOSC2_INSTALL_PREFIX" >> $GITHUB_ENV
-          echo "ISAL_INSTALL_PREFIX=$ISAL_INSTALL_PREFIX" >> $GITHUB_ENV
-
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BLOSC2_INSTALL_PREFIX/lib:$BLOSC2_INSTALL_PREFIX/lib64:$ISAL_INSTALL_PREFIX/lib:$ISAL_INSTALL_PREFIX/lib64" >> $GITHUB_ENV
-
-          # so we'll just use 'cross' to build and pass it in for the action for all archs
-          # nothing special for the revision pin, just deterministic install
-          cargo install cross --git https://github.com/cross-rs/cross --rev 6d097fb
-
-          # Build blosc2
-          cross build --release --target $TARGET_TRIPLE --package blosc2-sys --target-dir build
-          blosc2_sys_dir=$(ls build/$TARGET_TRIPLE/release/build/ | grep blosc2-sys)
-          mv $WORKSPACE/build/$TARGET_TRIPLE/release/build/$blosc2_sys_dir/out $BLOSC2_INSTALL_PREFIX
-          tree -L 2 $BLOSC2_INSTALL_PREFIX
-
-          # Build isal only on 64-bit systems
-          # At the time of this writing, it technically builds for all unix 32-bit systems
-          # but ISA-L has explicitly stated they're dropping support.
-          if [[ "$TARGET_TRIPLE" == armv7* || "$TARGET_TRIPLE" == i686* ]]; then
-            echo "Not building ISA-L on 32 bit target"
-            mkdir -p $ISAL_INSTALL_PREFIX
-          else
-            cross build --release --target $TARGET_TRIPLE --package isal-sys --target-dir build
-            isal_sys_dir=$(ls build/$TARGET_TRIPLE/release/build/ | grep isal-sys)
-            mv $WORKSPACE/build/$TARGET_TRIPLE/release/build/$isal_sys_dir/out $ISAL_INSTALL_PREFIX
-            tree -L 2 $ISAL_INSTALL_PREFIX
-          fi
-
       - name: Rust Tests
         if: matrix.conf.target == 'x86_64' && !startsWith(matrix.python-version, 'pypy') && matrix.python-version == '3.12'
         run: cargo test
 
-      - name: Build wheel (Linux)
-        if: runner.os == 'Linux'
+      - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.conf.target }}
           manylinux: ${{ matrix.conf.manylinux }}
-          docker-options: |
-            -e BLOSC2_INSTALL_PREFIX=${{ github.workspace }}/blosc2
-            -e ISAL_INSTALL_PREFIX=${{ github.workspace }}/isal
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/blosc2/lib:${{ github.workspace }}/blosc2/lib64:${{ github.workspace }}/isal/lib:${{ github.workspace }}/isal/lib64
-          args: -i ${{ matrix.python-version }} --release --out dist --features use-system-blosc2-static --features use-system-isal-static
-          before-script-linux: |
-            ls -l $BLOSC2_INSTALL_PREFIX
-            ls -l $ISAL_INSTALL_PREFIX
-
-      - name: Build wheel (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          python -m pip install maturin delvewheel
-          maturin build -i python --release --out wheels --target ${{ matrix.conf.target-triple }}
-          $file = Get-ChildItem -Path "wheels" | Select-Object -First 1
-          delvewheel repair -v "wheels\$($file.Name)" -w "dist"
-
-      - name: Build wheel (MacOS)
-        if: runner.os == 'macOS'
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.conf.target-triple }}
-          args: -i python --release --out dist
-
-      - name: Fix wheel (MacOS)
-        if: runner.os == 'macOS'
-        run: |
-          python -m pip install delocate
-          delocate-wheel -v dist/*.whl
+          args: -i ${{ matrix.python-version }} --release --out dist
     
       - name: Install built wheel and Test (Native)
         # TODO: I'm not sure but the actual collection of tests on windows using pypy3.10 takes forever and/or fails

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -96,12 +96,21 @@ jobs:
         if: matrix.conf.target == 'x86_64' && !startsWith(matrix.python-version, 'pypy') && matrix.python-version == '3.12'
         run: cargo test
 
-      - name: Build wheel
+      - name: Build wheel (OSX - Linux)
+        if: runner.os != 'Windows'
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.conf.target }}
           manylinux: ${{ matrix.conf.manylinux }}
           args: -i ${{ matrix.python-version }} --release --out dist
+
+      - name: Build wheel (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          python -m pip install maturin delvewheel
+          maturin build -i python --release --out wheels --target ${{ matrix.conf.target-triple }}
+          $file = Get-ChildItem -Path "wheels" | Select-Object -First 1
+          delvewheel repair -v "wheels\$($file.Name)" -w "dist"
     
       - name: Install built wheel and Test (Native)
         # TODO: I'm not sure but the actual collection of tests on windows using pypy3.10 takes forever and/or fails

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Set MSVC developer prompt
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Rust Tests
         if: matrix.conf.target == 'x86_64' && !startsWith(matrix.python-version, 'pypy') && matrix.python-version == '3.12'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,6 +88,10 @@ jobs:
         with:
           target: ${{ matrix.conf.target-triple }}
 
+      - name: Set MSVC developer prompt
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v
+
       - name: Rust Tests
         if: matrix.conf.target == 'x86_64' && !startsWith(matrix.python-version, 'pypy') && matrix.python-version == '3.12'
         run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "cramjam-python"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "libcramjam",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "cramjam-python"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "libcramjam",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cramjam-python"
-version = "2.9.1"
+version = "2.10.0"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ name = "cramjam"
 crate-type = ["cdylib"]
 
 [features]
-default                  = ["extension-module", "snappy", "lz4", "bzip2", "brotli", "xz", "zstd", "gzip", "zlib", "deflate", "blosc2", "igzip", "ideflate", "izlib"]
+default                  = ["extension-module", "snappy", "lz4", "bzip2", "brotli", "xz", "zstd", "gzip", "zlib", "deflate"]
+experimental             = ["blosc2", "igzip", "ideflate", "izlib"]
+
 extension-module         = ["pyo3/extension-module"]
 generate-import-lib      = ["pyo3/generate-import-lib"]  # needed for Windows PyPy builds
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Available algorithms:
 - [X] Deflate&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`cramjam.deflate`
 - [X] ZSTD&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`cramjam.zstd`
 - [X] XZ / LZMA&nbsp;&nbsp;`cramjam.xz`
+
+
+Experimental (Requires build from source enabling each feature):
+
 - [X] Blosc2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`cramjam.experimental.blosc2`
 - [X] ISA-L backend  _(only on 64-bit targets)_
   - [X] igzip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`cramjam.experimental.igzip`

--- a/benchmarks/test_bench.py
+++ b/benchmarks/test_bench.py
@@ -6,7 +6,8 @@ import numpy as np
 
 
 if hasattr(cramjam, "experimental") and not hasattr(cramjam, "blosc2"):
-    cramjam.blosc2 = cramjam.experimental.blosc2
+    if hasattr(cramjam.experimental, "blosc2"):
+        cramjam.blosc2 = cramjam.experimental.blosc2
 
 
 class Bzip2CompressedFile:
@@ -72,6 +73,9 @@ def test_blosc2(benchmark, file, use_cramjam: bool):
     Uses snappy compression raw
     """
     import blosc2
+
+    if not hasattr(cramjam, "blosc2"):
+        pytest.skip("blosc2 not built")
 
     data = file.read_bytes()
     if use_cramjam:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cramjam"
-version = "2.9.1"
+version = "2.10.0"
 keywords = ["compression", "decompression", "snappy", "zstd", "bz2", "gzip", "lz4", "brotli", "deflate", "blosc2"]
 requires-python = ">=3.8"
 license = { file = "LICENSE" }

--- a/tests/test_blosc2.py
+++ b/tests/test_blosc2.py
@@ -12,6 +12,10 @@ except ImportError:
 else:
     if hasattr(experimental, "blosc2"):
         blosc2 = experimental.blosc2
+    else:
+        pytest.skip(
+            "experimental module doesn't contain blosc2", allow_module_level=True
+        )
 
 
 settings.register_profile("local", max_examples=10)

--- a/tests/test_blosc2.py
+++ b/tests/test_blosc2.py
@@ -10,7 +10,8 @@ try:
 except ImportError:
     pytest.skip("experimental module not built", allow_module_level=True)
 else:
-    blosc2 = experimental.blosc2
+    if hasattr(experimental, "blosc2"):
+        blosc2 = experimental.blosc2
 
 
 settings.register_profile("local", max_examples=10)
@@ -25,7 +26,7 @@ else:
 def variants(e):
     for attr in dir(e):
         # TODO: LastCodec, LastFilter, LastRegisteredCodec/Filter not supported
-        if not attr.startswith('_') and not attr.lower().startswith('last'):
+        if not attr.startswith("_") and not attr.lower().startswith("last"):
             yield getattr(e, attr)
 
 
@@ -47,7 +48,9 @@ def test_roundtrip_chunk_into(data, codec, filter, clevel):
     kwargs = dict(clevel=clevel, filter=filter, codec=codec)
     nbytes_compressed = len(blosc2.compress_chunk(data, **kwargs))
 
-    compressed = np.empty(blosc2.max_compressed_len(len(data.tobytes())), dtype=np.uint8)
+    compressed = np.empty(
+        blosc2.max_compressed_len(len(data.tobytes())), dtype=np.uint8
+    )
     nbytes = blosc2.compress_chunk_into(data, compressed, **kwargs)
 
     decompressed = np.empty(len(data.tobytes()) * 2, dtype=np.uint8)


### PR DESCRIPTION
Kinda sad to do this, but most of the maintenance in this project is regarding the experimental modules like isal and blosc2. 

It's awfully fun trying to get these things working, but I just don't have the bandwidth lately. For now I'm going to remove blosc2 and igzip, izlib, and ideflate from the default builds. Still available in `experimental` feature or enabling those features as desired. Might come back later and add a `cramjam-experimental` package or something so `cramjam` "stable" doesn't cause so much noise to those maintaining platform packages.