### PR TITLE
Update PyO3 to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -512,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
 dependencies = [
  "once_cell",
  "python3-dll-a",
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -533,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "python3-dll-a"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9e268ee1be609e93a13eb06839f68f67e5fe0fb4049834d261c2d5091c1b6d"
+checksum = "9b66f9171950e674e64bad3456e11bb3cca108e5c34844383cfe277f45c8a7a8"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,11 +65,11 @@ wasm32-compat            = ["libcramjam/wasm32-compat"]
 
 
 [dependencies]
-pyo3 = { version = "^0.22", default-features = false, features = ["macros"] }
+pyo3 = { version = "^0.23", default-features = false, features = ["macros"] }
 libcramjam = { version = "^0.6", default-features = false }
 
 [build-dependencies]
-pyo3-build-config = "^0.22"
+pyo3-build-config = "^0.23"
 
 [profile.release]
 strip = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ dev = [
   "pytest>=5.30",
   "pytest-xdist",
   "pytest-benchmark",
-  "hypothesis"
+  "hypothesis<6.123.0"
 ]

--- a/src/io.rs
+++ b/src/io.rs
@@ -514,14 +514,14 @@ fn write<W: Write>(input: &mut BytesType, output: &mut W) -> std::io::Result<u64
 
 fn read<'a, R: Read>(reader: &mut R, py: Python<'a>, n_bytes: Option<usize>) -> PyResult<Bound<'a, PyBytes>> {
     match n_bytes {
-        Some(n) => PyBytes::new_bound_with(py, n, |buf| {
+        Some(n) => PyBytes::new_with(py, n, |buf| {
             reader.read(buf)?;
             Ok(())
         }),
         None => {
             let mut buf = vec![];
             reader.read_to_end(&mut buf)?;
-            Ok(PyBytes::new_bound(py, buf.as_slice()))
+            Ok(PyBytes::new(py, buf.as_slice()))
         }
     }
 }


### PR DESCRIPTION
Opening as a draft to see how CI feels about this change and because `lock().unwrap()` may swallow panics incorrectly.