### PR TITLE
Bump libcramjam -> 0.7 (in Cargo.toml, to match Cargo.lock)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ wasm32-compat            = ["libcramjam/wasm32-compat"]
 
 [dependencies]
 pyo3 = { version = "^0.23", default-features = false, features = ["macros"] }
-libcramjam = { version = "^0.6", default-features = false }
+libcramjam = { version = "^0.7", default-features = false }
 
 [build-dependencies]
 pyo3-build-config = "^0.23"


### PR DESCRIPTION
This is a follow-up to https://github.com/milesgranger/cramjam/pull/198.