### PR TITLE
Ban mutating immutable buffers on the free-threaded build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,7 +136,8 @@ jobs:
           python -m pip install cramjam[dev] --pre --find-links dist --force-reinstall
           python -m pip install cramjam --pre --no-index --find-links dist --force-reinstall
 
-          python -m pytest -vs --benchmark-skip
+          pip install pytest-rerunfailures
+          python -m pytest -vs --benchmark-skip --reruns 3 -n0 --dist no
 
       # Could use 'distro: alpine_latest' in 'run-on-arch-action' but seems difficult to install a specific version of python
       # so we'll just use existing python alpine images to test import and cli use w/o testing archs other than x86_64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,8 +136,7 @@ jobs:
           python -m pip install cramjam[dev] --pre --find-links dist --force-reinstall
           python -m pip install cramjam --pre --no-index --find-links dist --force-reinstall
 
-          pip install pytest-rerunfailures
-          python -m pytest -vs --benchmark-skip --reruns 3 -n0 --dist no
+          python -m pytest -vs --benchmark-skip -n0 --dist no
 
       # Could use 'distro: alpine_latest' in 'run-on-arch-action' but seems difficult to install a specific version of python
       # so we'll just use existing python alpine images to test import and cli use w/o testing archs other than x86_64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,11 +544,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
+checksum = "f239d656363bcee73afef85277f1b281e8ac6212a1d42aa90e55b90ed43c47a4"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -562,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
+checksum = "755ea671a1c34044fa165247aaf6f419ca39caa6003aee791a0df2713d8f1b6d"
 dependencies = [
  "once_cell",
  "python3-dll-a",
@@ -573,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
+checksum = "fc95a2e67091e44791d4ea300ff744be5293f394f1bafd9f78c080814d35956e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -583,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
+checksum = "a179641d1b93920829a62f15e87c0ed791b6c8db2271ba0fd7c2686090510214"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -595,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
+checksum = "9dff85ebcaab8c441b0e3f7ae40a6963ecea8a9f5e74f647e33fcf5ec9a1e89e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,11 +65,11 @@ wasm32-compat            = ["libcramjam/wasm32-compat"]
 
 
 [dependencies]
-pyo3 = { version = "^0.24", default-features = false, features = ["macros"] }
+pyo3 = { version = "^0.25", default-features = false, features = ["macros"] }
 libcramjam = { version = "^0.7", default-features = false }
 
 [build-dependencies]
-pyo3-build-config = "^0.24"
+pyo3-build-config = "^0.25"
 
 [profile.release]
 strip = true

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BASE_BENCH_CMD = python -m pytest -v --benchmark-sort name --benchmark-only benchmarks/ -k
 
 test:
-	python -m pytest tests -n auto -v --ignore benchmarks
+	python -m pytest -vs --benchmark-skip -n0 --dist no
 
 test-bench:
 	python -m pytest -v --benchmark-disable benchmarks/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ dev = [
   "pytest>=5.30",
   "pytest-xdist",
   "pytest-benchmark",
-  "hypothesis<6.123.0"
+  "hypothesis"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ dev = [
   "pytest>=5.30",
   "pytest-xdist",
   "pytest-benchmark",
-  "hypothesis"
+  "hypothesis==6.60.0"
 ]

--- a/src/io.rs
+++ b/src/io.rs
@@ -14,6 +14,7 @@ use pyo3::exceptions::{self, PyBufferError};
 use pyo3::ffi;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+use pyo3::IntoPyObjectExt;
 use std::path::PathBuf;
 
 pub(crate) trait AsBytes {
@@ -176,8 +177,8 @@ impl RustyFile {
 pub struct PythonBuffer {
     pub(crate) inner: std::pin::Pin<Box<ffi::Py_buffer>>,
     pub(crate) pos: usize,
-    #[cfg(PyPy)]
-    pub(crate) owner: PyObject,
+    #[cfg(any(PyPy, Py_GIL_DISABLED))]
+    pub(crate) owner: Py<PyAny>,
 }
 // PyBuffer is thread-safe: the shape of the buffer is immutable while a Py_buffer exists.
 // Accessing the buffer contents is protected using the GIL.
@@ -207,14 +208,23 @@ impl PythonBuffer {
     }
     /// Get the underlying buffer as a mutable slice of bytes
     pub fn as_slice_mut(&mut self) -> PyResult<&mut [u8]> {
-        #[cfg(PyPy)]
+        #[cfg(any(PyPy, Py_GIL_DISABLED))]
         {
             Python::with_gil(|py| {
                 let is_memoryview = unsafe { ffi::PyMemoryView_Check(self.owner.as_ptr()) } == 1;
                 if is_memoryview || self.owner.bind(py).is_instance_of::<PyBytes>() {
-                    Err(pyo3::exceptions::PyTypeError::new_err(
-                        "With PyPy, an output of type `bytes` or `memoryview` does not work. See issue pypy/pypy#4918",
-                    ))
+                    #[cfg(PyPy)]
+                    {
+                        Err(pyo3::exceptions::PyTypeError::new_err(
+                            "Cannot create mutable reference to `bytes` or `memoryview` on PyPy. See issue pypy/pypy#4918",
+                        ))
+                    }
+                    #[cfg(Py_GIL_DISABLED)]
+                    {
+                        Err(pyo3::exceptions::PyTypeError::new_err(
+                            "Cannot create mutable reference to `bytes` or `memoryview` on the free-threaded build. See issue milesgranger/cramjam#213"
+                        ))
+                    }
                 } else {
                     Ok(())
                 }
@@ -274,8 +284,8 @@ impl<'a, 'py> TryFrom<&'a Bound<'py, PyAny>> for PythonBuffer {
         let buf = Self {
             inner: std::pin::Pin::from(buf),
             pos: 0,
-            #[cfg(PyPy)]
-            owner: Python::with_gil(|py| obj.to_object(py)),
+            #[cfg(any(PyPy, Py_GIL_DISABLED))]
+            owner: Python::with_gil(|py| obj.into_py_any(py).unwrap()),
         };
         // sanity checks
         if buf.inner.shape.is_null() {
@@ -412,7 +422,6 @@ impl RustyBuffer {
     pub fn __init__(py: Python, mut data: Option<Py<PyAny>>, copy: Option<bool>) -> PyResult<Self> {
         if let Some(maybe_bytestype) = data.as_mut() {
             let mut bytestype = maybe_bytestype.extract::<BytesType<'_>>(py)?;
-
             if copy.unwrap_or(true) {
                 let mut buf = vec![];
                 bytestype.read_to_end(&mut buf)?;
@@ -648,7 +657,6 @@ impl RustyBuffer {
         (*view).buf = bytes.as_ptr() as *mut std::os::raw::c_void;
         (*view).len = bytes.len() as isize;
         (*view).readonly = 0;
-        (*view).itemsize = 1;
 
         (*view).format = std::ptr::null_mut();
         if (flags & ffi::PyBUF_FORMAT) == ffi::PyBUF_FORMAT {

--- a/src/io.rs
+++ b/src/io.rs
@@ -657,6 +657,7 @@ impl RustyBuffer {
         (*view).buf = bytes.as_ptr() as *mut std::os::raw::c_void;
         (*view).len = bytes.len() as isize;
         (*view).readonly = 0;
+        (*view).itemsize = 1;
 
         (*view).format = std::ptr::null_mut();
         if (flags & ffi::PyBUF_FORMAT) == ffi::PyBUF_FORMAT {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import platform
+import sysconfig
 
 import pytest
 
@@ -7,6 +8,10 @@ import pytest
 def is_pypy():
     impl = platform.python_implementation()
     return impl.lower() == "pypy"
+
+@pytest.fixture(scope="session")
+def is_free_threaded():
+    return bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
 
 def pytest_configure(config):

--- a/tests/test_buffer_view.py
+++ b/tests/test_buffer_view.py
@@ -12,7 +12,7 @@ def test_buffer_view(copy):
     if copy is not None:
         kwargs["copy"] = copy
 
-    data = b"bytes"
+    data = bytearray(b"bytes")
     buf = Buffer(data, **kwargs)
     buf.write(b"0")
 
@@ -26,7 +26,7 @@ def test_buffer_view(copy):
 
 @pytest.mark.skip_pypy
 def test_buffer_view_raises_when_writing_past_data_length_at_once():
-    data = b"bytes"
+    data = bytearray(b"bytes")
     buf = Buffer(data, copy=False)
 
     # Won't write pasted underlying buffer if passed data all at once
@@ -74,7 +74,7 @@ def test_buffer_view_raises_when_truncating():
 @pytest.mark.skip_pypy
 @pytest.mark.parametrize("whence", (0, 1, 2))
 def test_buffer_view_raises_when_write_after_bad_seek(whence):
-    buf = Buffer(b"bytes", copy=False)
+    buf = Buffer(bytearray(b"bytes"), copy=False)
 
     buf.seek(2, whence=0)  # Seek forward 2 from start, also okay
     buf.seek(2, whence=1)  # Seek forward 2 from current position, okay

--- a/tests/test_buffer_view.py
+++ b/tests/test_buffer_view.py
@@ -99,7 +99,7 @@ def test_buffer_view_cleanup():
     n_refs = 0
 
     def get_buffer():
-        data = b"bytes"
+        data = bytearray(b"bytes")
         buf = cramjam.Buffer(data, copy=False)
 
         nonlocal n_refs

--- a/tests/test_buffer_view.py
+++ b/tests/test_buffer_view.py
@@ -37,7 +37,7 @@ def test_buffer_view_raises_when_writing_past_data_length_at_once():
 
 @pytest.mark.skip_pypy
 def test_buffer_view_raises_when_writing_past_data_length_incrementally():
-    data = b"bytes"
+    data = bytearray(b"bytes")
     buf = Buffer(data, copy=False)
 
     # This is okay, up to length of underlying buffer

--- a/tests/test_rust_io.py
+++ b/tests/test_rust_io.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from cramjam import File, Buffer
@@ -30,7 +32,8 @@ def test_obj_api(tmpdir, Obj, is_pypy, is_free_threaded):
     ):
         buf.seek(0)
 
-        if isinstance(out, bytes) and (is_pypy or is_free_threaded):
+        if isinstance(out, bytes) and (
+                is_pypy or (is_free_threaded and sys.version_info >= (3, 14))):
             with pytest.raises(OSError):
                 buf.readinto(out)
             continue

--- a/tests/test_rust_io.py
+++ b/tests/test_rust_io.py
@@ -4,7 +4,7 @@ from cramjam import File, Buffer
 
 
 @pytest.mark.parametrize("Obj", (File, Buffer))
-def test_obj_api(tmpdir, Obj, is_pypy):
+def test_obj_api(tmpdir, Obj, is_pypy, is_free_threaded):
     if isinstance(Obj, File):
         buf = File(str(tmpdir.join("file.txt")))
     else:
@@ -30,7 +30,7 @@ def test_obj_api(tmpdir, Obj, is_pypy):
     ):
         buf.seek(0)
 
-        if isinstance(out, bytes) and is_pypy:
+        if isinstance(out, bytes) and (is_pypy or is_free_threaded):
             with pytest.raises(OSError):
                 buf.readinto(out)
             continue

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -106,7 +106,7 @@ def test_variants_raise_exception(variant_str):
 @pytest.mark.parametrize("variant_str", VARIANTS)
 @given(raw_data=st.binary())
 def test_variants_compress_into(
-    variant_str, input_type, output_type, raw_data, tmp_path_factory, is_pypy
+        variant_str, input_type, output_type, raw_data, tmp_path_factory, is_pypy, is_free_threaded
 ):
     # TODO: Fix segfault when using blosc2 compress_into cramjam.File
     #       decompress_into appears to work fine.
@@ -148,9 +148,9 @@ def test_variants_compress_into(
     else:
         output = output_type(b"0" * compressed_len)
 
-    if is_pypy and isinstance(output, (bytes, memoryview)):
+    if (is_pypy or is_free_threaded) and isinstance(output, (bytes, memoryview)):
         pytest.xfail(
-            reason="PyPy de/compress_into w/ bytes or memoryview is a bit flaky behavior"
+            reason="Decompressing into immutable objects is not supported on PyPy or the free-threaded build"
         )
 
     n_bytes = variant.compress_into(input, output)
@@ -176,7 +176,7 @@ def test_variants_compress_into(
 @pytest.mark.parametrize("variant_str", VARIANTS)
 @given(raw_data=st.binary())
 def test_variants_decompress_into(
-    variant_str, input_type, output_type, tmp_path_factory, raw_data, is_pypy
+    variant_str, input_type, output_type, tmp_path_factory, raw_data, is_pypy, is_free_threaded
 ):
     if variant_str == "izlib" and output_type == "memoryview":
         pytest.skip("See issue https://github.com/milesgranger/cramjam/issues/193")
@@ -213,9 +213,9 @@ def test_variants_decompress_into(
     else:
         output = output_type(b"0" * len(raw_data))
 
-    if is_pypy and isinstance(output, (bytes, memoryview)):
+    if (is_pypy or is_free_threaded) and isinstance(output, (bytes, memoryview)):
         pytest.xfail(
-            reason="PyPy de/compress_into w/ bytes or memoryview is a bit flaky behavior"
+            reason="Decompressing into immutable objects is not supported on PyPy or the free-threaded build"
         )
 
     n_bytes = variant.decompress_into(input, output)

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -62,7 +62,7 @@ def test_variants_different_dtypes(variant_str, arr, is_pypy):
             try:
                 compressed = variant.compress(arr)
             except:
-                pytest.xfail(
+                pytest.skip(
                     reason="PyPy struggles w/ multidim buffer views depending on dtype ie datetime[64]"
                 )
         else:
@@ -106,7 +106,13 @@ def test_variants_raise_exception(variant_str):
 @pytest.mark.parametrize("variant_str", VARIANTS)
 @given(raw_data=st.binary())
 def test_variants_compress_into(
-        variant_str, input_type, output_type, raw_data, tmp_path_factory, is_pypy, is_free_threaded
+    variant_str,
+    input_type,
+    output_type,
+    raw_data,
+    tmp_path_factory,
+    is_pypy,
+    is_free_threaded,
 ):
     # TODO: Fix segfault when using blosc2 compress_into cramjam.File
     #       decompress_into appears to work fine.
@@ -149,7 +155,7 @@ def test_variants_compress_into(
         output = output_type(b"0" * compressed_len)
 
     if (is_pypy or is_free_threaded) and isinstance(output, (bytes, memoryview)):
-        pytest.xfail(
+        pytest.skip(
             reason="Decompressing into immutable objects is not supported on PyPy or the free-threaded build"
         )
 
@@ -176,7 +182,13 @@ def test_variants_compress_into(
 @pytest.mark.parametrize("variant_str", VARIANTS)
 @given(raw_data=st.binary())
 def test_variants_decompress_into(
-    variant_str, input_type, output_type, tmp_path_factory, raw_data, is_pypy, is_free_threaded
+    variant_str,
+    input_type,
+    output_type,
+    tmp_path_factory,
+    raw_data,
+    is_pypy,
+    is_free_threaded,
 ):
     if variant_str == "izlib" and output_type == "memoryview":
         pytest.skip("See issue https://github.com/milesgranger/cramjam/issues/193")
@@ -214,7 +226,7 @@ def test_variants_decompress_into(
         output = output_type(b"0" * len(raw_data))
 
     if (is_pypy or is_free_threaded) and isinstance(output, (bytes, memoryview)):
-        pytest.xfail(
+        pytest.skip(
             reason="Decompressing into immutable objects is not supported on PyPy or the free-threaded build"
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -129,7 +129,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = "==22.3.0" },
-    { name = "hypothesis", marker = "extra == 'dev'", specifier = "<6.123.0" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.60.0" },
     { name = "numpy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=5.30" },
     { name = "pytest-benchmark", marker = "extra == 'dev'" },
@@ -181,16 +181,16 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.113.0"
+version = "6.60.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/32/6513cd7256f38c19a6c8a1d5ce9792bcd35c7f11651989994731f0e97672/hypothesis-6.113.0.tar.gz", hash = "sha256:5556ac66fdf72a4ccd5d237810f7cf6bdcd00534a4485015ef881af26e20f7c7", size = 408897 }
+sdist = { url = "https://files.pythonhosted.org/packages/93/01/9eb666fa63b2de2b143d7ff69a4bf8aadb965b25eccbdc9addde37f2c42c/hypothesis-6.60.0.tar.gz", hash = "sha256:39c06cd49f491204380d7c7aa45389d3fb84ee80ea1e3f10afc744044aceb751", size = 336039 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/fa/4acb477b86a94571958bd337eae5baf334d21b8c98a04b594d0dad381ba8/hypothesis-6.113.0-py3-none-any.whl", hash = "sha256:d539180eb2bb71ed28a23dfe94e67c851f9b09f3ccc4125afad43f17e32e2bad", size = 469790 },
+    { url = "https://files.pythonhosted.org/packages/91/8e/10b1d619c832e9fd028e7d0d52dca9cf8e53d36544177c45c91eddd04aca/hypothesis-6.60.0-py3-none-any.whl", hash = "sha256:3e8a1e061a6bfa3d8c282dafec100f2c8c527ea50b6560e9a33adf0e2e5fef8f", size = 398044 },
 ]
 
 [[package]]


### PR DESCRIPTION
See https://github.com/milesgranger/cramjam/issues/213#issuecomment-2888784450.

Makes tests that mutate buffers use a `bytearray`, which works on all builds.

Also fixes the build on PyPy - this was missed in a previous PyO3 update.