### PR TITLE
Fix lz4.decompress_block_into w/o prepended size

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,8 @@
 """
-Test decompressing files which have been compressed from 
+Test decompressing files which have been compressed from
 main stream third party implementations, separate from this project.
 """
+
 import sys
 import lzma
 import pathlib
@@ -52,7 +53,6 @@ def test_variant(variant: Variant, integration_dir: pathlib.Path, plaintext: byt
 @given(data=st.binary(min_size=1, max_size=int(1e6)))
 @pytest.mark.parametrize("format", (lzma.FORMAT_ALONE, lzma.FORMAT_XZ))
 def test_lzma_compat(data, format):
-
     # Decompress from std lzma lib
     compressed = lzma.compress(data, format=format)
     uncompressed = cramjam.xz.decompress(compressed)
@@ -65,3 +65,38 @@ def test_lzma_compat(data, format):
     compressed = cramjam.xz.compress(data, format=cjformat)
     uncompressed = lzma.decompress(bytes(compressed), format=format)
     assert same_same(uncompressed, data)
+
+
+@given(data=st.binary(min_size=1, max_size=int(1e6)))
+@pytest.mark.parametrize("set_output_len", (True, False))
+def test_lz4_decompress_block_into_non_prepended_size(data, set_output_len):
+    compressed = cramjam.lz4.compress_block(data, store_size=False)
+
+    # Check both scenarios of user explicitly providing output_len or not
+    output_len = len(data) if set_output_len else None
+
+    # If we have data, and the output buffer isn't long enough
+    # it ought to fail
+    if data:
+        with pytest.raises(cramjam.DecompressionError):
+            cramjam.lz4.decompress_block_into(
+                compressed, bytearray(0), output_len=output_len
+            )
+
+        # But if we explicitly provide the right output_len,
+        # while the output is less, we'll know why.
+        match = f"output_len set to {len(data)}, but output is less"
+        with pytest.raises(cramjam.DecompressionError, match=match):
+            cramjam.lz4.decompress_block_into(
+                compressed, bytearray(0), output_len=len(data)
+            )
+
+    # If it's the same length as original data, it's okay.
+    out = bytearray(len(data))
+    n = cramjam.lz4.decompress_block_into(compressed, out, output_len=output_len)
+    assert same_same(bytes(out), data)
+
+    # pre-allocated buffer is larger, also okay
+    out = bytearray(len(compressed) * 2)
+    n = cramjam.lz4.decompress_block_into(compressed, out, output_len=output_len)
+    assert same_same(bytes(out[:n]), data)


### PR DESCRIPTION
Will close #216 

Uses new `output_len` parameter to try to determine if size is prepended, falling back to trying the opposite in case we assumed wrong or the user got it wrong.

Additional help check if output_len is provided but the output length is smaller.