### PR TITLE
unpin hypothesis and disable assertion rewrites in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -183,7 +183,8 @@ jobs:
           python -m pip install cramjam[dev] --pre --find-links dist --force-reinstall
           python -m pip install cramjam --pre --no-index --find-links dist --force-reinstall
 
-          python -m pytest -vs --benchmark-skip -n0 --dist no
+          # remove --assert='plain' when https://github.com/HypothesisWorks/hypothesis/issues/4267 is fixed
+          python -m pytest --assert='plain' -vs --benchmark-skip -n0 --dist no
 
       # Could use 'distro: alpine_latest' in 'run-on-arch-action' but seems difficult to install a specific version of python
       # so we'll just use existing python alpine images to test import and cli use w/o testing archs other than x86_64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ dev = [
   "pytest>=5.30",
   "pytest-xdist",
   "pytest-benchmark",
-  "hypothesis==6.60.0"
+  "hypothesis"
 ]


### PR DESCRIPTION
Workaround for https://github.com/milesgranger/cramjam/issues/201. I was hitting issues using `pytest-run-parallel` locally with the old hypothesis version. Passing `--assert='plain'` seems to avoid the crash.