### PR TITLE
Configure `python-source` to include type stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires = ["maturin>=0.14"]
 build-backend = "maturin"
 
 [tool.maturin]
+python-source = "src"
 strip = true
 
 [dependency-groups]


### PR DESCRIPTION
Although source code contains stub files with type annotations, they are not included into the package. And the `__init__.py` is autogenerated by maturin, not used those provided in the source:
```shell
❯ unzip -l cramjam-2.11.0-cp314-cp314-macosx_11_0_arm64.whl
Archive:  cramjam-2.11.0-cp314-cp314-macosx_11_0_arm64.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
     5561  07-27-2025 21:10   cramjam-2.11.0.dist-info/METADATA
      104  07-27-2025 21:10   cramjam-2.11.0.dist-info/WHEEL
     1070  07-27-2025 21:10   cramjam-2.11.0.dist-info/licenses/LICENSE
      111  07-27-2025 21:10   cramjam/__init__.py
  3722064  07-27-2025 21:10   cramjam/cramjam.cpython-314-darwin.so
      480  07-27-2025 21:10   cramjam-2.11.0.dist-info/RECORD
---------                     -------
  3729390                     6 files
```

Auto-discover of python code doesn't work with this layout, so we have to configure `python-source` explicitly. The content of package after this fix:
```shell
❯ unzip -l dist/cramjam-2.12.0rc1-cp313-cp313-macosx_11_0_arm64.whl 
Archive:  dist/cramjam-2.12.0rc1-cp313-cp313-macosx_11_0_arm64.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
      684  09-28-2025 15:05   cramjam-2.12.0rc1.dist-info/METADATA
      104  09-28-2025 15:05   cramjam-2.12.0rc1.dist-info/WHEEL
     1070  09-28-2025 15:05   cramjam-2.12.0rc1.dist-info/licenses/LICENSE
     1247  09-28-2025 15:05   cramjam/gzip.pyi
     5809  09-28-2025 15:05   cramjam/__init__.pyi
     4157  09-28-2025 15:05   cramjam/lz4.pyi
       23  09-28-2025 15:05   cramjam/__init__.py
     1247  09-28-2025 15:05   cramjam/zlib.pyi
     2109  09-28-2025 15:05   cramjam/deflate.pyi
     3155  09-28-2025 15:05   cramjam/xz.pyi
        0  09-28-2025 15:05   cramjam/experimental.pyi
     1251  09-28-2025 15:05   cramjam/bzip2.pyi
     2020  09-28-2025 15:05   cramjam/brotli.pyi
        0  09-28-2025 15:05   cramjam/py.typed
     3105  09-28-2025 15:05   cramjam/snappy.pyi
     1247  09-28-2025 15:05   cramjam/zstd.pyi
  8697136  09-28-2025 15:05   cramjam/cramjam.cpython-313-darwin.so
     1377  09-28-2025 15:05   cramjam-2.12.0rc1.dist-info/RECORD
---------                     -------
  8725741                     18 files
```